### PR TITLE
chore(proxy): remove pgadmin from proxy, remove redundand scripts

### DIFF
--- a/.env
+++ b/.env
@@ -6,10 +6,7 @@ PGADMIN_DEFAULT_EMAIL=admin@admin.com
 PGADMIN_DEFAULT_PASSWORD=admin
 
 DOTNET_EnableDiagnostics=1
-
 ASPNETCORE_ENVIRONMENT=Development
-ASPNETCORE__Kestrel__Certificates__Default__Path="certs/https/development.pfx"
-ASPNETCORE__Kestrel__Certificates__Default__Password=1111
 
 ConnectionStrings__TodoListDbConnection="Host=db;Port=5432;Database=todolist;Username=postgres;Password=postgres"
 
@@ -25,6 +22,5 @@ Serilog__MinimumLevel__Overrides__TodoList.Service=Debug
 
 TODOLIST_HTTP_PORT=8080
 IDENTITY_HTTP_PORT=8081
-
 
 COMPOSE_PROFILES=tools,backend,frontend

--- a/.github/workflows/docker-compose-run.yml
+++ b/.github/workflows/docker-compose-run.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Docker Compose
         run: |
           npm run docker:build
-          npm run docker:fullstack:detach
+          npm run docker:run:detach
 
       - name: Verify if services are running
         run: docker compose ps

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,17 +1,21 @@
 localhost {
-  handle /todolist/* {
+  handle /todolist/swagger/* {
     reverse_proxy todolistservice:8080
   }
 
-  handle /identity/* {
+  handle /identity/swagger/* {
     reverse_proxy identityservice:8081
   }
 
-  handle_path /pgadmin/* {
-    reverse_proxy pgadmin:80
+  handle_path /todolist/* {
+    reverse_proxy todolistservice:8080
   }
 
-  reverse_proxy / {
-    to todolistclient:4000
+  handle_path /identity/* {
+    reverse_proxy identityservice:8081
+  }
+
+  handle /* {
+    reverse_proxy todolistclient:4000
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       - identity
     environment:
       - ASPNETCORE_ENVIRONMENT
-      - ASPNETCORE__Kestrel__Certificates__Default__Path
-      - ASPNETCORE__Kestrel__Certificates__Default__Password
       - ConnectionStrings__TodoListDbConnection
       - Jwt__Issuer
       - Jwt__Audience

--- a/package.json
+++ b/package.json
@@ -11,13 +11,8 @@
     "caddy:trust": "choco install caddy --yes --force && powershell -Command \"Start-Process -NoNewWindow -FilePath 'caddy' -ArgumentList 'run --config Caddyfile'; Start-Sleep -Seconds 5; caddy trust; Stop-Process -Name caddy -Force\"",
     "docker:build": "docker compose -f docker-compose.yml build",
     "docker:build:debug": "docker compose -f docker-compose.yml -f docker-compose.debug.yml build",
-    "docker:build:nocache": "docker compose -f docker-compose.yml build --no-cache",
-    "docker:build:debug:nocache": "docker compose -f docker-compose.yml -f docker-compose.debug.yml build --no-cache",
-    "docker:tools": "docker compose -f docker-compose.yml -f docker-compose.debug.yml --profile db --profile tools --profile proxy up",
-    "docker:backend:tools": "docker compose -f docker-compose.yml -f docker-compose.debug.yml --profile backend --profile tools --profile proxy up",
-    "docker:identity:tools": "docker compose -f docker-compose.yml -f docker-compose.debug.yml --profile identity --profile db --profile tools --profile proxy up",
-    "docker:fullstack": "docker compose -f docker-compose.yml --profile frontend --profile backend --profile proxy up",
-    "docker:fullstack:tools": "docker compose -f docker-compose.yml --profile frontend --profile backend --profile tools --profile proxy up",
-    "docker:fullstack:detach": "docker compose -f docker-compose.yml --profile frontend --profile backend --profile proxy up -d"
+    "docker:run:db": "docker compose -f docker-compose.yml --profile db --profile tools",
+    "docker:run": "docker compose -f docker-compose.yml --profile frontend --profile backend --profile tools --profile proxy up",
+    "docker:run:detach": "docker compose -f docker-compose.yml --profile frontend --profile backend --profile proxy up -d"
   }
 }


### PR DESCRIPTION
## Description

- Pgadmin works strange under proxy so it's better to not expose it via Caddy.
- Scripts to run different docker compose profiles were removed as Caddy doesn't work well when some services are down.

